### PR TITLE
uncomment logic to detect labels

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -7,11 +7,13 @@ from rest_framework.response import Response
 from .utils import detect_labels, classify_label, get_unconfigured_labels
 
 # api/recognition/recognize
+
+
 class ImageLabelRecognizer(APIView):
     '''
     Recognize the labels in image using amazon's Rekognition service
     '''
-    #permission_classes = [
+    # permission_classes = [
     #    IsAuthenticatedOrReadOnly]  # making read only for time being, else esp auth token ould need to be flashed again and again.
 
     def get(self, request: Request):
@@ -38,49 +40,47 @@ class ImageLabelRecognizer(APIView):
 
         img_file = request.FILES.get('image_file', False)
 
-        # if img_file and not img_file.readable():
-        #     msg = {'msg':'image_file not readable'}
-        #     status_code = 400
-        # elif img_file:
-        #     labels = detect_labels(img_file.read())
-        #     if labels:
-        #         msg = classify_label(labels)
-        #         status_code = 200
-        #     else:
-        #         msg = {
-        #             'msg':'service not responding properly',
-        #             'error':True,
-        #         }
+        if img_file and not img_file.readable():
+            msg = {'msg': 'image_file not readable'}
+            status_code = 400
 
-        # below var is only for development purpose
-        labels = [
-            {
-                "Name": "Tin",
-                "Confidence": 94.43530731201172,
-                "Aliases": []
-            },
-            {
-                "Name": "Plastic",
-                "Confidence": 98.45320892333984,
-                "Aliases": []
-            },
-            {
-                "Name": "Can",
-                "Confidence": 94.63530731201172,
-                "Aliases": []
-            },
-        ]
+        elif img_file:
+            labels = detect_labels(img_file.read())
+            print(labels)
+            if labels:
+                msg = classify_label(labels)
+                status_code = 200
 
-        msg = classify_label(labels)
+            resformat = request.query_params.get('format', 'text')
 
-        if msg:
-            status_code = 200
+            if resformat == 'text':
+                msg = msg.get('class')
+                content_type = 'plain/text'
+                response_func = HttpResponse
 
-        resformat = request.query_params.get('format', 'text')
-
-        if resformat == 'text':
-            msg = msg.get('class')
-            content_type = 'plain/text'
-            response_func = HttpResponse
+        else:
+            msg = {
+                'msg': 'service not responding properly',
+                'error': True,
+            }
 
         return response_func(msg, status=status_code, content_type=content_type)
+
+        # # below var is only for development purpose
+        # labels = [
+        #     {
+        #         "Name": "Tin",
+        #         "Confidence": 94.43530731201172,
+        #         "Aliases": []
+        #     },
+        #     {
+        #         "Name": "Plastic",
+        #         "Confidence": 98.45320892333984,
+        #         "Aliases": []
+        #     },
+        #     {
+        #         "Name": "Can",
+        #         "Confidence": 94.63530731201172,
+        #         "Aliases": []
+        #     },
+        # ]


### PR DESCRIPTION
## :file_folder: recognition/views.py
    Bugs and Vulnerabilities can be found in below section along with their fixes.


    ### :bug: Bugs

    1. The import statement at the beginning should have a relative path, for example: `from .utils import detect_labels, classify_label, get_unconfigured_labels`.
2. The commented out `permission_classes` attribute should be removed or uncommented.
3. The `status_code` and `content_type` variables should be initialized before the if-else statement.
4. The `msg` variable should be initialized to an empty dictionary or a default error message in case none of the conditions in the if-else statement are met.
5. There is a missing indentation on the return statement, it should be indented inside the else block.
6. The response format logic is incomplete, as it only covers the 'text' format case. It should also cover other formats such as JSON.
7. There are no logical errors but there are implementation issues related to error handling and response format.


    ### :lock: Vulns

    1. Potential vulnerability in section 1:

- The commented out `permission_classes` attribute suggests that the endpoint is not properly secured, as anyone can access it without authentication.
- The `get_unconfigured_labels` function could potentially return sensitive information if it's not properly secured.

To fix these vulnerabilities, we should:
- Uncomment the `permission_classes` attribute and set it to a proper permission class that requires authentication.
- Ensure that the `get_unconfigured_labels` function is properly secured and only returns non-sensitive information if accessed without proper authorization.

2. Potential vulnerability in section 2:

- There is no check for the file type, which could allow an attacker to upload a malicious file (e.g. a script that executes arbitrary code on the server).
- The `detect_labels` function is relying on an external service (Amazon's Rekognition), which could potentially introduce security risks or privacy concerns.
- The `resformat` parameter is not properly sanitized, which could allow an attacker to inject malicious code into the response.

To fix these vulnerabilities, we should:
- Add a check for the file type and only allow certain file types to be uploaded.
- Consider creating our own label detection function or using a trusted library instead of relying on a third-party service.
- Sanitize the `resformat` parameter before using it in the response to prevent injection attacks.


